### PR TITLE
Fix for PHP7: define an array in case one does not exist.

### DIFF
--- a/MomentjsAsset.php
+++ b/MomentjsAsset.php
@@ -26,6 +26,10 @@ class MomentjsAsset extends \yii\web\AssetBundle
             $this->js = ['moment-with-locales.min.js'];
             //assing locale globally
             $key = md5($js = "moment.locale('$language');");
+            if(!isset($view->js[$view::POS_READY])){
+                $view->js[$view::POS_READY] = [];
+            }            
+            
             $view->js[$view::POS_READY] = [$key => $js] + (array)$view->js[$view::POS_READY];
         } else {
             $this->js = ['moment.min.js'];


### PR DESCRIPTION
In the case of PHP 7 having an empty array causes an error. Therefore, we create an empty array if one does not exist for $view->js[$view::POS_READY]